### PR TITLE
Fixed eclipsegotosuper

### DIFF
--- a/.vrapperrc
+++ b/.vrapperrc
@@ -98,7 +98,7 @@ eclipseuiaction eclipseshowdoc org.eclipse.ui.edit.text.showInformation
 nnoremap K   :eclipseshowdoc<cr>
 
 " go to super implementation
-eclipseaction eclipsegotosuper org.eclipse.java.ui.edit.text.java.open.super.implementation
+eclipseaction eclipsegotosuper org.eclipse.jdt.ui.edit.text.java.open.super.implementation
 nnoremap gzi :eclipsegotosuper<cr>
 
 "show refactor menu


### PR DESCRIPTION
Hello,

I am not sure if you are sill using Eclipse/Vrapper but I found your shortcuts and I did not know that it is possible to define them that way.

Anyhow eclipsegotosuper points to the wrong Action definition ID (https://git.eclipse.org/r/plugins/gitiles/jdt/eclipse.jdt.ui/+/89ea2c6596fdcfa355e79600261b224a899708ac/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/IJavaEditorActionDefinitionIds.java) 

Perhaps they changed it over the course of time?